### PR TITLE
Adjust deserialization types for get_torrent_status

### DIFF
--- a/lib/deserialization.dart
+++ b/lib/deserialization.dart
@@ -338,29 +338,9 @@ class TorrentOptions {
 
 @customDeserialize
 class Tracker {
-  @MapKey('send_stats')
-  late bool sendStats;
-
-  late int fails;
-
-  late bool verified;
-
   late String url;
 
-  @MapKey('fail_limit')
-  late int failLimit;
-
-  @MapKey('complete_sent')
-  late bool completeSent;
-
-  late int source;
-
-  @MapKey('start_sent')
-  late bool startSent;
-
   late int tier;
-
-  late bool updating;
 }
 
 @customDeserialize

--- a/lib/deserialization.g.dart
+++ b/lib/deserialization.g.dart
@@ -328,16 +328,8 @@ class $TrackerCustomDeserializer extends CustomDeserializer<Tracker> {
     var oAsMap = (o as Map<Object, Object?>);
     var map = oAsMap.cast<String, Object?>();
     var item = Tracker();
-    item.sendStats = map['send_stats'] as bool;
-    item.fails = map['fails'] as int;
-    item.verified = map['verified'] as bool;
     item.url = map['url'] as String;
-    item.failLimit = map['fail_limit'] as int;
-    item.completeSent = map['complete_sent'] as bool;
-    item.source = map['source'] as int;
-    item.startSent = map['start_sent'] as bool;
     item.tier = map['tier'] as int;
-    item.updating = map['updating'] as bool;
     return item;
   }
 }

--- a/lib/trireme_client.dart
+++ b/lib/trireme_client.dart
@@ -138,7 +138,7 @@ abstract class TriremeClient {
   Future setTorrentTrackers(String torrentId, List<Map> trackers);
 
   @ApiName('core.get_torrent_status')
-  Future<Response<Map<String, Object>>> getTorrentStatus(
+  Future<Response<Map<String, Object?>>> getTorrentStatus(
       String torrentId, List<String> keys);
 
   @ApiName('core.get_torrent_status')

--- a/lib/trireme_client.g.dart
+++ b/lib/trireme_client.g.dart
@@ -168,12 +168,12 @@ class _$TriremeClientImpl extends TriremeClient {
   }
 
   @override
-  Future<Response<Map<String, Object>>> getTorrentStatus(
+  Future<Response<Map<String, Object?>>> getTorrentStatus(
       String torrentId, List<String> keys) async {
     var result = await _client.rpcCall<Response<Object>>(
         'core.get_torrent_status', [torrentId, keys]);
     var resultUnwrapped = result.response as Map<Object, Object?>;
-    var result2 = resultUnwrapped.cast<String, Object>();
+    var result2 = resultUnwrapped.cast<String, Object?>();
     return Response(result.apiName, result.requestId, result2);
   }
 


### PR DESCRIPTION
This commits fixes issues with the return types of some calls that had partially incorrect types.

- `getTorrentStatus()`, which fetches all availables attributes from the Deluge daemon, did not allow for null (None) values even though they can be returned in some cases. See [deluge/core/torrent.py:1539](https://github.com/deluge-torrent/deluge/blob/develop/deluge/core/torrent.py#L1539), pieces will be None for completed downloads.
- The `Tracker` object included a set of attributes that are only sometimes available. These attributes are obtained from libtorrent when a torrent is first added. However, once the trackers have been edited from the Deluge UI, only the "tier" and "url" field will be available. These are persisted in the daemon's state, and the extra attributes from libtorrent are never re-synced.
See [deluge/core/torrent.py:574](https://github.com/deluge-torrent/deluge/blob/develop/deluge/core/torrent.py#L574) and [deluge/core/torrent.py:602](https://github.com/deluge-torrent/deluge/blob/develop/deluge/core/torrent.py#L602)

In the second case, the removed fields were not exposed in the Trireme app nor the Deluge client. There is no impact on end users.